### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@
 TBMInspectorView is a copy of the Xcode 5's inspector view. It is pretty easy to setup and should be set as the documentView of a NSScrollView.
 
 ## Adding to your Project
-If your are using [Cocoapods](http://cocoapods.org/) simply add the following to your Podfile
+If your are using [CocoaPods](http://cocoapods.org/) simply add the following to your Podfile
 
 ``` ruby
 pod 'TBMInspectorView'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
